### PR TITLE
kernel/ and de/: Standardizing symbols for pointers and variables

### DIFF
--- a/kernel/kres/dev/chardev/i8042/ps2kbd.c
+++ b/kernel/kres/dev/chardev/i8042/ps2kbd.c
@@ -177,10 +177,10 @@ void DeviceInterface_PS2Keyboard(void)
         return;
 
 // =============================================
-// Não precisamos perguntar para o controlador se
-// podemos ler, porque foi uma interrupção que nos trouxe aqui.
+// We don't need to control if we can read
+// because was an interruption that brought us here.
 // #obs:
-// O byte pode ser uma resposta à um comando ou um scancode.
+// The byte may be a response to a command or a scancode.
 
 //sc_again:
 
@@ -213,16 +213,17 @@ void DeviceInterface_PS2Keyboard(void)
 //++
 // ===========================================
 // #todo
-// Temos que checar se o primeiro byte é um ack ou um resend.
-// isso acontece logo apos a inicialização.
+// We have to check if the first byte is an ack or a resend.
+// This all happen right after the initialization.
 // #todo
-// me parece que o primeiro byte pode ser um ack ou resend.
+// for me looks like that the first byte can be an ack or resend.
 // #define ACKNOWLEDGE         0xFA
 // #define RESEND              0xFE
 
 // ??
 // Assim como no mouse, talvez o ack so seja enviado
-// quando estivermos em modo streaming.
+// Like a mouse, maybe the ack just be sent
+// when we're in the streaming mode.
 
     switch (__raw){
 

--- a/mods/crt/kstdio.c
+++ b/mods/crt/kstdio.c
@@ -30,7 +30,7 @@ static void __kstdio_puts(const char* str)
 {
     register int i=0;
     ssize_t StringLen=0;
-    int _char=0;
+    int character=0;
 
     if (ModuleInitialization.initialized != TRUE){
         return;
@@ -47,10 +47,10 @@ static void __kstdio_puts(const char* str)
 // Print chars. 
     for (i=0; i<StringLen; i++)
     {
-        _char = (int) ( str[i] & 0xFF );
+        character = (int) ( str[i] & 0xFF );
         caller1( 
             kfunctions[PUTCHAR_FGCONSOLE], 
-            _char ); 
+            character ); 
     };
 }
 
@@ -110,7 +110,7 @@ int newm0_initialize(void)
 // The kernel static entry point.
 // #bugbug: It's not safe.
 // We need a random address.
-    unsigned char *k = (unsigned char *) 0x30001000;
+    unsigned char *kernel = (unsigned char *) 0x30001000;
 
 // #test
 // Lookup for "__GRAMADO__"
@@ -123,21 +123,21 @@ int newm0_initialize(void)
 
     for (i=0; i<100; i++)
     {
-        if (k[i+0]  == '_' &&
-            k[i+1]  == '_' &&
-            k[i+2]  == 'G' &&
-            k[i+3]  == 'R' &&
-            k[i+4]  == 'A' &&
-            k[i+5]  == 'M' &&
-            k[i+6]  == 'A' &&
-            k[i+7]  == 'D' &&
-            k[i+8]  == 'O' &&
-            k[i+9]  == '_' &&
-            k[i+10] == '_')
+        if (kernel[i+0]  == '_' &&
+            kernel[i+1]  == '_' &&
+            kernel[i+2]  == 'G' &&
+            kernel[i+3]  == 'R' &&
+            kernel[i+4]  == 'A' &&
+            kernel[i+5]  == 'M' &&
+            kernel[i+6]  == 'A' &&
+            kernel[i+7]  == 'D' &&
+            kernel[i+8]  == 'O' &&
+            kernel[i+9]  == '_' &&
+            kernel[i+10] == '_')
         {
             Found = 1;
             // The function table starts here.
-            __function_table = (unsigned long) &k[i+11];
+            __function_table = (unsigned long) &kernel[i+11];
         }
     };
 
@@ -162,18 +162,18 @@ fail:
     return FALSE;
 }
 
-void newm0_print_string (char *s)
+void newm0_print_string (char *ptr_string)
 {
     register int i=0;
     int size=0;
-    size = module_strlen(s);
+    size = module_strlen(ptr_string);
     if (size <= 0)
         return;
     for (i=0; i<size; i++)
     {
         caller1( 
             kfunctions[PUTCHAR_FGCONSOLE], 
-            s[i] );
+            ptr_string[i] );
     };
 }
 
@@ -186,7 +186,7 @@ char *kinguio_itoa (int val, char *str)
     char *valuestring = (char *) str;
     int min_flag=0;
     char swap=0; 
-    char *p;
+    char *ptr;
 
     if (0 > value)
     {
@@ -194,10 +194,10 @@ char *kinguio_itoa (int val, char *str)
         value = -____INT_MAX> value ? min_flag = ____INT_MAX : -value;
     }
 
-    p = valuestring;
+    ptr = valuestring;
 
     do {
-         *p++ = (char) (value % 10) + '0';
+         *ptr++ = (char) (value % 10) + '0';
          value /= 10;
     } while (value);
 
@@ -206,13 +206,13 @@ char *kinguio_itoa (int val, char *str)
         ++*valuestring;
     }
 
-    *p-- = '\0';
+    *ptr-- = '\0';
 
-    while (p > valuestring)
+    while (ptr > valuestring)
     {
         swap = *valuestring;
-        *valuestring++ = *p;
-        *p-- = swap;
+        *valuestring++ = *ptr;
+        *ptr-- = swap;
     };
 
     return str;
@@ -224,47 +224,47 @@ kinguio_i2hex(
     char *dest, 
     int len )
 {
-    char *cp;
+    char *ptr_character;
     register int i=0;
     int x=0;
     unsigned n=0;  //??
 
     if (val == 0)
     {
-        cp = &dest[0];
-        *cp++ = '0';
-        *cp = '\0';
+        ptr_character = &dest[0];
+        *ptr_character++ = '0';
+        *ptr_character = '\0';
         return;
     }
 
     n = val;
-    cp = &dest[len];
+    ptr_character = &dest[len];
 
-    while (cp > dest)
+    while (ptr_character > dest)
     {
         x = (n & 0xF);
         n >>= 4;
         
         // #
-        *--cp = x + ((x > (HEX_LEN+1)) ? 'A' - 10 : '0');
+        *--ptr_character = x + ((x > (HEX_LEN+1)) ? 'A' - 10 : '0');
     };
 
     dest[len] = '\0';
 
-    cp = &dest[0];
+    ptr_character = &dest[0];
 
     for (i=0; i<len; i++)
     {
-        if (*cp == '0'){
-            cp++;
+        if (*ptr_character == '0'){
+            ptr_character++;
         }else{
-            strcpy (dest,cp);
+            strcpy (dest,ptr_character);
             break;
         };
     }
 
-    cp = &dest[0];
-    n = module_strlen(cp);
+    ptr_character = &dest[0];
+    n = module_strlen(ptr_character);
 
     memset( (dest+n), 0, (8-n) );
 }

--- a/mods/include/crt/kstdio.h
+++ b/mods/include/crt/kstdio.h
@@ -12,7 +12,7 @@ struct module_initialization_d
 };
 extern struct module_initialization_d  ModuleInitialization;
 
-void newm0_print_string (char *s);
+void newm0_print_string (char *ptr_string);
 int newm0_1001(void);
 int newm0_initialize(void);
 


### PR DESCRIPTION
I saw that the variable names and pointers don't look well self-explained, i know that we can't always have awesome variable names specially when its not something that we're going to see much times, this is the case of the  kstdio functions, something that we'll most of time just use instead of modify.

But since its an open source project, one of the beautiful things that open source give for us is tools/sources to learn, so for new contributors or even students that will use gramado as a example OS, is good have a good readability.

Seeing that i started to standardize some parts, if you have any sugestion or critic about some part of the code, im open to discuss about the best way to make the code more clear.